### PR TITLE
Add an event to map HTTP_ACCEPT headers to Joomla format types

### DIFF
--- a/libraries/src/CMS/Application/ApiApplication.php
+++ b/libraries/src/CMS/Application/ApiApplication.php
@@ -34,7 +34,7 @@ final class ApiApplication extends CMSApplication
 	 * @var    array
 	 * @since  __DEPLOY_VERSION__
 	 */
-	public $formatMapper = [];
+	protected $formatMapper = [];
 
 	/**
 	 * Class constructor.
@@ -62,6 +62,8 @@ final class ApiApplication extends CMSApplication
 
 		// Execute the parent constructor
 		parent::__construct($input, $config, $client, $container);
+
+		$this->addFormatMap('application/vnd.api+json', 'jsonapi');
 
 		// Set the root in the URI based on the application name
 		\JUri::root(null, str_ireplace('/' . $this->getName(), '', \JUri::base(true)));
@@ -99,20 +101,17 @@ final class ApiApplication extends CMSApplication
 	}
 
 	/**
-	 * Initialise the application.
+	 * Adds a mapping from a content type to the format stored. Note the format type cannot be overwritten.
 	 *
-	 * @param   array  $options  An optional associative array of configuration settings.
-	 *
-	 * @return  void
-	 *
-	 * @since   3.2
+	 * @param   string  $contentHeader  The content header
+	 * @param $format
 	 */
-	protected function initialiseApp($options = array())
+	public function addFormatMap($contentHeader, $format)
 	{
-		parent::initialiseApp($options);
-
-		// This is a core supported type so force it!
-		$this->formatMapper['application/vnd.api+json'] = 'jsonapi';
+		if (!array_key_exists($contentHeader, $this->formatMapper))
+		{
+			$this->formatMapper[$contentHeader] = $format;
+		}
 	}
 
 	/**

--- a/libraries/src/CMS/Application/ApiApplication.php
+++ b/libraries/src/CMS/Application/ApiApplication.php
@@ -34,7 +34,7 @@ final class ApiApplication extends CMSApplication
 	 * @var    array
 	 * @since  __DEPLOY_VERSION__
 	 */
-	protected $formatMapper = [];
+	public $formatMapper = [];
 
 	/**
 	 * Class constructor.
@@ -62,11 +62,6 @@ final class ApiApplication extends CMSApplication
 
 		// Execute the parent constructor
 		parent::__construct($input, $config, $client, $container);
-
-		$this->triggerEvent('onGetApiFormats', [$this->formatMapper]);
-
-		// This is a core supported type so force it!
-		$this->formatMapper['application/vnd.api+json'] = 'jsonapi';
 
 		// Set the root in the URI based on the application name
 		\JUri::root(null, str_ireplace('/' . $this->getName(), '', \JUri::base(true)));
@@ -101,6 +96,23 @@ final class ApiApplication extends CMSApplication
 
 		// Mark afterDispatch in the profiler.
 		JDEBUG ? $this->profiler->mark('afterDispatch') : null;
+	}
+
+	/**
+	 * Initialise the application.
+	 *
+	 * @param   array  $options  An optional associative array of configuration settings.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.2
+	 */
+	protected function initialiseApp($options = array())
+	{
+		parent::initialiseApp($options);
+
+		// This is a core supported type so force it!
+		$this->formatMapper['application/vnd.api+json'] = 'jsonapi';
 	}
 
 	/**

--- a/libraries/src/CMS/Application/ApiApplication.php
+++ b/libraries/src/CMS/Application/ApiApplication.php
@@ -29,6 +29,14 @@ use Negotiation\Negotiator;
 final class ApiApplication extends CMSApplication
 {
 	/**
+	 * Maps extension types to their
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $formatMapper = [];
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param   \JInput    $input      An optional argument to provide dependency injection for the application's input
@@ -54,6 +62,11 @@ final class ApiApplication extends CMSApplication
 
 		// Execute the parent constructor
 		parent::__construct($input, $config, $client, $container);
+
+		$this->triggerEvent('onGetApiFormats', [$this->formatMapper]);
+
+		// This is a core supported type so force it!
+		$this->formatMapper['application/vnd.api+json'] = 'jsonapi';
 
 		// Set the root in the URI based on the application name
 		\JUri::root(null, str_ireplace('/' . $this->getName(), '', \JUri::base(true)));
@@ -201,7 +214,14 @@ final class ApiApplication extends CMSApplication
 		}
 
 		/** @var $mediaType Accept */
-		$this->input->set('format', $mediaType->getValue());
+		$format = $mediaType->getValue();
+
+		if (array_key_exists($mediaType->getValue(), $this->formatMapper))
+		{
+			$format = $this->formatMapper[$mediaType->getValue()];
+		}
+
+		$this->input->set('format', $format);
 		$this->input->set('option', $route['vars']['component']);
 		$this->input->set('controller', $route['controller']);
 		$this->input->set('task', $route['task']);


### PR DESCRIPTION
Adds an event for mapping the accept header to a Joomla Format type. So we don't end up insane classnames like JDocumentApplicationvndapijson