### PR TITLE
Ensure lang exists. Potential for new entry points

### DIFF
--- a/libraries/src/CMS/Component/ComponentHelper.php
+++ b/libraries/src/CMS/Component/ComponentHelper.php
@@ -306,13 +306,13 @@ class ComponentHelper
 	 */
 	public static function renderComponent($option, $params = array())
 	{
-		$app = \JFactory::getApplication();
+		$app  = \JFactory::getApplication();
+		$lang = \JFactory::getLanguage();
 
 		if (!$app->isClient('api'))
 		{
 			// Load template language files.
 			$template = $app->getTemplate(true)->template;
-			$lang = \JFactory::getLanguage();
 			$lang->load('tpl_' . $template, JPATH_BASE, null, false, true)
 				|| $lang->load('tpl_' . $template, JPATH_THEMES . "/$template", null, false, true);
 		}
@@ -377,21 +377,17 @@ class ComponentHelper
 			// Dispatch the component.
 			$contents = static::dispatchComponent(new $class($app, $app->input));
 		}
-		else
+		elseif (file_exists(JPATH_COMPONENT . '/' . $file . '.php'))
 		{
-			$path = JPATH_COMPONENT . '/' . $file . '.php';
-
-			// If component file doesn't exist throw error
-			if (!file_exists($path))
-			{
-				throw new \Exception(\JText::_('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND'), 404);
-			}
-
 			// Load common and local language files.
 			$lang->load($option, JPATH_BASE, null, false, true) || $lang->load($option, JPATH_COMPONENT, null, false, true);
 
 			// Execute the component.
-			$contents = static::executeComponent($path);
+			$contents = static::executeComponent(JPATH_COMPONENT . '/' . $file . '.php');
+		}
+		else
+		{
+			throw new \Exception(\JText::_('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND'), 404);
 		}
 
 		// Revert the scope


### PR DESCRIPTION
- Ensures `$lang` is always defined (as it's used later on if there's a main entry file). Reworks where the exception is thrown (in an else) so I can add an alternative dispatcher for API apps later